### PR TITLE
Support for task arguments with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,19 @@ ARCH=$(shell uname -m)
 ORG=progrium
 VERSION=0.4.1
 
+ifdef LDFLAGS
+    override LDFLAGS += # This appends a blank space to separate ldflag arguments
+endif
+
 .PHONY: build release dep
 
 build: dep
 	go build ./...
 	go test ./...
 	mkdir -p build/Darwin
-	go build -a -installsuffix cgo -ldflags "-X main.Version=$(VERSION)" -o build/Darwin/entrykit ./cmd
+	go build -a -installsuffix cgo -ldflags "$(LDFLAGS)-X main.Version=$(VERSION)" -o build/Darwin/entrykit ./cmd
 	mkdir -p build/Linux
-	go build -a -installsuffix cgo -ldflags "-X main.Version=$(VERSION)" -o build/Linux/entrykit ./cmd
+	go build -a -installsuffix cgo -ldflags "$(LDFLAGS)-X main.Version=$(VERSION)" -o build/Linux/entrykit ./cmd
 
 dep:
 	GO111MODULE=on go mod tidy


### PR DESCRIPTION
Using an entrykit command like:
```
codep perl -E 'say "hi"'
```
would throw an error message regarding not being able to find the closing quote. This is due to how the task parameters were being split and passed to `exec.Command` resulting in:
```
[ "perl", "-E", "'say", "\"hi\"'" ]
```

This PR splits arguments on whitespace that's not contained within quotes resulting in:
```
[ "perl", "-E", "'say \"hi\"'" ]
```
being passed to `exec.Command`
