### PR TITLE
Fix race condition

### DIFF
--- a/codep/codep.go
+++ b/codep/codep.go
@@ -28,9 +28,13 @@ func Codep(tasks map[string]string) error {
 
 	for _, task := range tasks {
 		cmd := entrykit.CommandTask(task)
+		err := cmd.Start()
+		if err != nil {
+			return err
+		}
 		cmds = append(cmds, cmd)
 		go func() {
-			done <- cmd.Run()
+			done <- cmd.Wait()
 		}()
 	}
 	entrykit.ProxySignals(cmds)

--- a/codep/codep_test.go
+++ b/codep/codep_test.go
@@ -1,0 +1,9 @@
+package codep
+
+import (
+	"testing"
+)
+
+func TestCodepNonExistent(t *testing.T) {
+	Codep(map[string]string{"non-existent1": "non-existent1", "non-existent2": "non-existent2"})
+}


### PR DESCRIPTION
I found a race condition which results in a segfault - `go test -count 1000 ./...` without `
0a67846 ` manages to reproduce the issue very reliably.

Ideally, I'd like to handle the error case of `cmd.Start()` more elegantly (eg. sending a signal to started children and waiting for them to terminate), but this will do for now.